### PR TITLE
Fix accidental overriding of checkmark icon background image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 
+## 0.1.1 - 2019-04-10
+
+### Fixed:
+- Switch from `background` to `background-color` to stop
+  accidentally overriding the checkmark icon background image
+  and get the checkmark icon back.
+
+
 ## 0.1.0 - 2019-04-09
 
 Initial release.

--- a/src/custom.css
+++ b/src/custom.css
@@ -181,7 +181,7 @@ h6 {
 .Skin .LabelWrapper > label.SingleAnswer > span:before,
 .Skin .LabelWrapper > label.MultipleAnswer > span:before {
     border: 1px solid #919395;
-    background: white !important;
+    background-color: white !important;
 }
 
 .Skin #Buttons #NextButton,


### PR DESCRIPTION
Before:

![Checked checkbox missing the checkmark icon](https://user-images.githubusercontent.com/1044670/55893455-430a3b00-5b86-11e9-94e9-29db95a28113.png)

After:

![Screen Shot 2019-04-10 at 11 50 29](https://user-images.githubusercontent.com/1044670/55893726-de9bab80-5b86-11e9-8573-b91d9bbcfb58.png)

